### PR TITLE
Enable use as argument matcher

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,14 +28,25 @@ In your `spec_helper.rb`:
     config.json_schemas[:my_schema] = "path/to/schema.json"
     #inline
     config.json_schemas[:inline_schema] = '{"type": "string"}'
-    
+
 You can then write tests such as:
 
 	#passing spec
     expect('"hello world"').to match_json_schema(:inline_schema)
-    
+
     #failing spec
     expect('[1, 2, 3]').to match_json_schema(:inline_schema)
+
+It also works as an argument matcher:
+
+    expect(some_object).to receive(:some_method).with(object_matching_schema(:inline_schema))
+
+The argument matcher will match anything that the underlying JSON-Schema validator knows how to validate, so if you want to
+limit your argument to a certain class, you'll need to add a compound matcher for that.
+
+    expect(some_object).to receive(:some_method)
+      .with(an_instance_of(String).and(object_matching_schema(:inline_schema)))
+
 
 #### Strict schema validation
 
@@ -46,7 +57,7 @@ those explicitly defined in your schema
 ```
 expect(response.body).to match_json_schema(:my_schema, strict: true)
 ```
-    
+
 ### Schema in a file
 You can also use rails path utilities such as `Rails.root.join("spec/support/schemas/my_business_object.schema.json").to_s` when defining schema locations. This gem is backed by the [json-schema](http://github.com/hoxworth/json-schema) gem, so whatever that validator accepts  for paths should work.
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,5 +1,28 @@
 require 'json-schema-rspec'
 
+# Copyright (c) 2012 David Chelimsky, Myron Marston
+# Copyright (c) 2006 David Chelimsky, The RSpec Development Team
+# Copyright (c) 2005 Steven Baker
+# Shamelessly stolen from rspec-mocks
+module RSpec
+  module ExpectationFailMatchers
+    def fail(&block)
+      raise_error(RSpec::Mocks::MockExpectationError, &block)
+    end
+
+    def fail_with(*args, &block)
+      raise_error(RSpec::Mocks::MockExpectationError, *args, &block)
+    end
+
+    def fail_including(*snippets)
+      raise_error(
+        RSpec::Mocks::MockExpectationError,
+        a_string_including(*snippets)
+      )
+    end
+  end
+end
+
 Dir[File.expand_path("../../spec/support/**/*.rb",__FILE__)].each { |f| require f }
 
 RSpec.configure do |config|
@@ -11,4 +34,5 @@ RSpec.configure do |config|
   config.filter_run_excluding wip: true
 
   config.include JSON::SchemaMatchers
+  config.include RSpec::ExpectationFailMatchers
 end


### PR DESCRIPTION
Let's you use the matcher class as an argument matcher with the "object_matching_schema" method.

It also outputs some helpful information in the diff output, rather than just returning false and saying it should have matched.